### PR TITLE
(build) Use build.bat for all build configurations

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -108,11 +108,15 @@ object RhinoLicensingSchd : BuildType({
 
     steps {
         powerShell {
-            name = "Prerequisites"
+            name = "Install dependencies"
             scriptMode = script {
                 content = """
-                    choco install windows-sdk-7.1 netfx-4.8-devpack visualstudio2022-workload-manageddesktopbuildtools --confirm --no-progress
-                    exit ${'$'}LastExitCode
+                    choco install netfx-4.8-devpack dotnetcore-sdk --confirm --no-progress
+
+                    ${'$'}result = ${'$'}LASTEXITCODE
+                    if (${'$'}result -notin 0, 1641, 3010) {
+                    	throw "One or more dependencies failed to install. Last exit code: ${'$'}result"
+                    }
                 """.trimIndent()
             }
         }
@@ -167,11 +171,15 @@ object RhinoLicensingQA : BuildType({
 
     steps {
         powerShell {
-            name = "Prerequisites"
+            name = "Install dependencies"
             scriptMode = script {
                 content = """
-                    choco install windows-sdk-7.1 netfx-4.8-devpack visualstudio2022-workload-manageddesktopbuildtools --confirm --no-progress
-                    exit ${'$'}LastExitCode
+                    choco install netfx-4.8-devpack dotnetcore-sdk --confirm --no-progress
+
+                    ${'$'}result = ${'$'}LASTEXITCODE
+                    if (${'$'}result -notin 0, 1641, 3010) {
+                    	throw "One or more dependencies failed to install. Last exit code: ${'$'}result"
+                    }
                 """.trimIndent()
             }
         }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -56,7 +56,7 @@ object RhinoLicensing : BuildType({
         script {
             name = "Call Cake"
             scriptContent = """
-                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
+                build.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
             """.trimIndent()
         }
     }
@@ -120,7 +120,7 @@ object RhinoLicensingSchd : BuildType({
         script {
             name = "Call Cake"
             scriptContent = """
-                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=all --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
+                build.bat --verbosity=diagnostic --target=CI --testExecutionType=all --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
             """.trimIndent()
         }
     }
@@ -179,7 +179,7 @@ object RhinoLicensingQA : BuildType({
         script {
             name = "Call Cake"
             scriptContent = """
-                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunSonarQube=true --shouldRunDependencyCheck=true --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
+                build.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunSonarQube=true --shouldRunDependencyCheck=true --shouldRunOpenCover=false --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldAuthenticodeSignOutputAssemblies=false --shouldAuthenticodeSignPowerShellScripts=false
             """.trimIndent()
         }
     }


### PR DESCRIPTION
## Description Of Changes

This MR ensures that all TeamCity build configurations use build.bat rather than build.official.bat.

## Motivation and Context

This project does not yet have a "ReleaseOfficial" project configuration which is used when executing `build.official.bat` and so the build configurations using this script were failing.

## Testing

WIP

## Change Types Made

* [x] Build related changes
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed.
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A